### PR TITLE
feat: adds additional fields to UserMetadata

### DIFF
--- a/src/models.rs
+++ b/src/models.rs
@@ -79,13 +79,19 @@ pub struct AppMetadata {
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Default)]
 pub struct UserMetadata {
     #[serde(skip_serializing_if = "Option::is_none")]
+    pub name: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub full_name: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub email: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub email_verified: Option<bool>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub phone_verified: Option<bool>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub sub: Option<String>,
+    pub picture: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub avatar_url: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]


### PR DESCRIPTION
## What kind of change does this PR introduce?

Adds the following fields to `UserMetadata`
1. name
2. full_name
3. photo
4. avatar_url

All are kept optional since we may/may not need to construct or de-contruct them all the time. This behaviour matches the JS SDK.