### PR TITLE
Fix Email OTP verify model definition to match JS API

### DIFF
--- a/src/models.rs
+++ b/src/models.rs
@@ -305,7 +305,9 @@ pub struct VerifyMobileOtpParams {
 
 #[derive(Default, Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct VerifyEmailOtpParams {
-    /// The user's phone number. pub email: String, The otp sent to the user's phone number.
+    /// The user's email.
+    pub email: String,
+    /// The otp sent to the user's email.
     pub token: String,
     /// The user's verification type.
     #[serde(rename = "type")]
@@ -331,7 +333,11 @@ pub enum OtpType {
     Signup,
     EmailChange,
     Sms,
+    Email,
     PhoneChange,
+    Invite,
+    Magiclink,
+    Recovery,
 }
 
 #[derive(Default, Debug, Clone, Serialize, Deserialize, PartialEq)]


### PR DESCRIPTION
## What kind of change does this PR introduce?

Fixes #30.

Updates the OTP email verification model to
- introduce the missing `email` field for  `VerifyEmailOtpParams`
- add the missing otp types to `OtpType`:  "email", "invite", "magiclink", "recovery".

With that, it matches the current JS API documentation.

## What is the current behavior?

As described in #30, the verify otp call crashes with a 400 Bad Request error, indicating that the email is a required field for the request.

## What is the new behavior?

The call for verifying OTP with email now suceeds. I don't have a phone/sms integration set up, so I wasn't able to test the remaining `OtpType`s. 