### PR TITLE
Save the session in the AuthClient

### DIFF
--- a/src/models.rs
+++ b/src/models.rs
@@ -5,6 +5,7 @@ use reqwest::{Client, Url};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use std::{collections::HashMap, fmt::Display};
+use std::cell::RefCell;
 use uuid::Uuid;
 
 /// Supabase Auth Client
@@ -18,6 +19,8 @@ pub struct AuthClient {
     pub(crate) api_key: String,
     /// Used to decode your JWTs. You can also use this to mint your own JWTs.
     pub(crate) jwt_secret: String,
+
+    pub(crate) session: RefCell<Option<Session>>,
 }
 
 #[derive(Default, Debug, Clone, Serialize, Deserialize, PartialEq)]


### PR DESCRIPTION
## What kind of change does this PR introduce?

New feature (idea for improvement):
The `Session` returned by the `login_***` methods is stored in the AuthClient itself.
This way the AuthClient could use the correct `access_token` in `get_user()`, `get_settings()`, etc. without requiring the developer to provide the access token as a method parameter. Same for the `refresh_token` in `refresh_session()` method.

## What is the current behavior?

The `Session` is returned from the `login_***()` methods and it is responsibility of the user application to pass the correct token where needed.

## What is the new behavior?

The `Session` is still returned by the `login_**()` methods and the user application may use it if needed.
But the AuthClient itself also keeps a handle to the last authenticated session and use its tokens appropriately where needed.

## Additional context

My idea is inspired by https://github.com/floris-xlx/supabase_rs/pull/42
There I want to authenticate the user via `supabase.auth().login_***()` and start doing `supabase.insert()/update()/select()/delete()`. By keeping a reference to the `Session` the insert/update/... operations could use the correct bearer depending on whether the user is authenticated or not:
https://github.com/floris-xlx/supabase_rs/pull/42/files#diff-b1a35a68f14e696205874893c07fd24fdb88882b47c23cc0e0c80a30c7d53759R432-R437
