### PR TITLE
stricter EmailSignUpConfirmation deserialization

### DIFF
--- a/src/models.rs
+++ b/src/models.rs
@@ -104,26 +104,17 @@ pub enum EmailSignUpResult {
     ConfirmationResult(EmailSignUpConfirmation),
 }
 
-#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Default)]
+#[derive(Clone, Debug, Deserialize, PartialEq, Default)]
 pub struct EmailSignUpConfirmation {
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub id: Option<Uuid>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub aud: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub role: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    pub id: Uuid,
+    pub aud: String,
+    pub role: String,
     pub email: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub phone: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub confirmation_sent_at: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub created_at: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub updated_at: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub is_anonymous: Option<bool>,
+    pub confirmation_sent_at: String,
+    pub created_at: String,
+    pub updated_at: String,
+    pub is_anonymous: bool,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

Due to an update I made a while ago, errors received from /signup are never returned by sign_up_with_email_and_password, because EmailSignUpConfirmation deserialization always succeeds even if the json didn't match, because it has all optional properties.

## What is the new behavior?

EmailSignUpConfirmation now has mostly required properties, so it won't deserialize if the result from supabase was an error.

## Additional context

I don't remember why I made EmailSignUpConfirmation have all optional properties, I was probably going off of the js auth client as an example, but I can't think of a reason they need to be optional. Let me know if you do. I also removed the Serialize trait since it's only deserialized.
